### PR TITLE
support mps device along with cpu and gpu

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,7 +6,7 @@ rtree==1.0.1
 typing-extensions>=4.10.0
 maplibre>=0.2.6
 shiny>=0.7.0
-segment-geospatial==0.11.0
+segment-geospatial==0.11.1
 geopandas==0.14.4
 shapely==2.0.4
 rasterio==1.3.9

--- a/app/utils/sam2.py
+++ b/app/utils/sam2.py
@@ -1,5 +1,5 @@
 import os
-from samgeo import SamGeo2
+from samgeo import SamGeo2, choose_device
 import torch
 from utils.utils import (
     generate_geojson,
@@ -10,7 +10,7 @@ from schemas.segment import SegmentRequestBase, SegmentResponseBase
 from utils.logger_config import log
 
 # Initialize the SAM model
-device = "cuda" if torch.cuda.is_available() else "cpu"
+device = choose_device()
 log.info(f"Using device: {device}")
 sam2 = SamGeo2(
     model_id="sam2-hiera-large",


### PR DESCRIPTION
writing up an attempt to get MPS support faster than CPU, marking as draft because it seems slower (?)

SAM2 supports some MPS acceleration: https://github.com/facebookresearch/sam2/pull/192 Samgeo supports this version of SAM2, so I made a small change to how this project chooses the device by using SamGeo's choose_device function.

Tested this locally on my mac m1 with ds-annotate running locally, pointing to my local samgeo-service

```
→ uv run uvicorn main:app --host 0.0.0.0 --port 8000 --reload --log-level debug
INFO:     Will watch for changes in these directories: ['/Users/ryanavery/samgeo-service/app']
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [19664] using WatchFiles
2024-10-06 20:43:59 - INFO - Using device: mps
```

<img width="1512" alt="Screenshot 2024-10-06 at 8 49 21 PM" src="https://github.com/user-attachments/assets/10cd245c-d5f3-44b9-929f-2313ad94bb5d">

This takes about 8 seconds. I'm not sure but I think this doesn't include computing image embeddings.

```
2024-10-06 20:48:38 - INFO - {'method': 'POST', 'path': '/segment_predictor', 'duration': 8.586161125000217}
```

this seemed kinda slow so I tried a similar multi point query and hard coded the cpu device

```
INFO:     127.0.0.1:59286 - "POST /segment_predictor HTTP/1.1" 200 OK
2024-10-06 20:59:24 - INFO - {'method': 'GET', 'path': '/', 'duration': 1.006952417003049}
```

So both device work but cpu seems faster? So anyway this PR might not actually be useful if cpu is actually faster than mps. SAM2 folks say MPS should be faster than cpu so I'm a bit confused. Thought I'd post this up just so folks can see that MPs in theory does work and I might come back to take a look later and see why mps is slower.

Awesome work getting multi-point support implemented!
