### PR TITLE
fix: Create required directories for static file serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     libopengl0
 
 WORKDIR /app
+RUN mkdir -p public tmp
 
 COPY ./app/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --root-user-action=ignore -r /app/requirements.txt


### PR DESCRIPTION
## What
- Add creation of required directories (`public` and `tmp`) in Dockerfile
- These directories are required for static file serving and temporary file storage in SAMGEO service

## Why
- Application fails to start with error: `RuntimeError: Directory 'public' does not exist`
- These directories are referenced in `main.py` but were not created during container build

## Changes
```diff
 # Dockerfile
 WORKDIR /app
+RUN mkdir -p public tmp
 
 COPY ./app /app
``` 

 ## Error Log

`RuntimeError: Directory 'public' does not exist`

<details>

```sh
uvicorn main:app --host 0.0.0.0 --port 80 --reload --log-level debug
INFO:     Will watch for changes in these directories: ['/app']
INFO:     Uvicorn running on http://0.0.0.0:80 (Press CTRL+C to quit)
INFO:     Started reloader process [272] using WatchFiles
2025-01-21 05:56:40 - INFO - Using device: cpu
2025-01-21 05:56:43 - INFO - Loaded checkpoint sucessfully
2025-01-21 05:56:46 - INFO - Loaded checkpoint sucessfully
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/opt/conda/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/conda/lib/python3.11/site-packages/uvicorn/_subprocess.py", line 76, in subprocess_started
    target(sockets=sockets)
  File "/opt/conda/lib/python3.11/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/uvicorn/server.py", line 68, in serve
    config.load()
  File "/opt/conda/lib/python3.11/site-packages/uvicorn/config.py", line 473, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/uvicorn/importer.py", line 21, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/main.py", line 46, in <module>
    app.mount("/files", StaticFiles(directory="public"), name="public")
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/starlette/staticfiles.py", line 56, in __init__
    raise RuntimeError(f"Directory '{directory}' does not exist")
RuntimeError: Directory 'public' does not exist
```

</details>
